### PR TITLE
Issue 20 null in heuristics

### DIFF
--- a/config/heuristicCompetitive/SpaceSettlersConfig.xml
+++ b/config/heuristicCompetitive/SpaceSettlersConfig.xml
@@ -45,7 +45,7 @@
 		</HighLevelTeamConfig>
 		<HighLevelTeamConfig>
 			<teamName>DoNothingTeam</teamName>
-			<configFile>amy-spacesettlersinit.xml</configFile>
+			<configFile>donothing-clientinit.xml</configFile>
 		</HighLevelTeamConfig>		
 		<HighLevelTeamConfig>
 			<teamName>CoreCollectorTeam</teamName>

--- a/config/heuristicCooperative/SpaceSettlersConfig.xml
+++ b/config/heuristicCooperative/SpaceSettlersConfig.xml
@@ -61,9 +61,6 @@
 			<teamName>BeaconCollectorTeam</teamName>
 		</BaseConfig>
 		<BaseConfig>
-			<teamName>HumanTeam</teamName>
-		</BaseConfig>
-		<BaseConfig>
 			<teamName>HeuristicMinerTeam</teamName>
 		</BaseConfig>
 	</bases>

--- a/src/spacesettlers/clients/AggressiveFlagCollectorTeamClient.java
+++ b/src/spacesettlers/clients/AggressiveFlagCollectorTeamClient.java
@@ -481,7 +481,7 @@ public class AggressiveFlagCollectorTeamClient extends TeamClient {
 
 		for (UUID asteroidId : asteroidToShipMap.keySet()) {
 			Asteroid asteroid = (Asteroid) space.getObjectById(asteroidId);
-			if (asteroid == null || !asteroid.isAlive() || asteroid.isMoveable()) {
+			if (asteroid != null && (!asteroid.isAlive() || asteroid.isMoveable())) {
  				finishedAsteroids.add(asteroid);
 				//System.out.println("Removing asteroid from map");
 			}

--- a/src/spacesettlers/clients/AggressiveHeuristicAsteroidCollectorSingletonTeamClient.java
+++ b/src/spacesettlers/clients/AggressiveHeuristicAsteroidCollectorSingletonTeamClient.java
@@ -298,7 +298,7 @@ public class AggressiveHeuristicAsteroidCollectorSingletonTeamClient extends Tea
 
 		for (UUID asteroidId : asteroidToShipMap.keySet()) {
 			Asteroid asteroid = (Asteroid) space.getObjectById(asteroidId);
-			if (asteroid == null || !asteroid.isAlive() || asteroid.isMoveable()) {
+			if (asteroid != null && (!asteroid.isAlive() || asteroid.isMoveable())) {
 				finishedAsteroids.add(asteroid);
 				//System.out.println("Removing asteroid from map");
 			}

--- a/src/spacesettlers/clients/AggressiveHeuristicAsteroidCollectorTeamClient.java
+++ b/src/spacesettlers/clients/AggressiveHeuristicAsteroidCollectorTeamClient.java
@@ -360,7 +360,7 @@ public class AggressiveHeuristicAsteroidCollectorTeamClient extends TeamClient {
 
 		for (UUID asteroidId : asteroidToShipMap.keySet()) {
 			Asteroid asteroid = (Asteroid) space.getObjectById(asteroidId);
-			if (asteroid == null || !asteroid.isAlive() || asteroid.isMoveable()) {
+			if (asteroid != null && (!asteroid.isAlive() || asteroid.isMoveable())) {
 				finishedAsteroids.add(asteroid);
 				//System.out.println("Removing asteroid from map");
 			}

--- a/src/spacesettlers/clients/PacifistHeuristicAsteroidCollectorTeamClient.java
+++ b/src/spacesettlers/clients/PacifistHeuristicAsteroidCollectorTeamClient.java
@@ -223,7 +223,7 @@ public class PacifistHeuristicAsteroidCollectorTeamClient extends TeamClient {
 
 		for (UUID asteroidId : asteroidToShipMap.keySet()) {
 			Asteroid asteroid = (Asteroid) space.getObjectById(asteroidId);
-			if (asteroid == null || !asteroid.isAlive() || asteroid.isMoveable()) {
+			if (asteroid != null && (!asteroid.isAlive() || asteroid.isMoveable())) {
  				finishedAsteroids.add(asteroid);
 				//System.out.println("Removing asteroid from map");
 			}


### PR DESCRIPTION
# Issue 20

#20 

## Updated Configs

I changed the SpaceSettlersConfig.xml for both cooperative and competitive to run on a fresh download.

## Fixed Null Pointer

I updated the `getMovementEnd()`s to properly check if an asteroid is null before adding it to the finished asteroids list.

## Note

I'm not sure where asteroids are being set to null, but this prevents the errors from showing up in the heuristics.

