### PR TITLE
Added damageReceived to deepClone of Ship

### DIFF
--- a/src/spacesettlers/objects/Ship.java
+++ b/src/spacesettlers/objects/Ship.java
@@ -124,6 +124,7 @@ public class Ship extends AbstractActionableObject {
 		newShip.killsInflicted = killsInflicted;
 		newShip.killsReceived = killsReceived;
 		newShip.damageInflicted = damageInflicted;
+		newShip.damageReceived = damageReceived;
 		newShip.carryingFlag = carryingFlag;
 		newShip.numFlags = numFlags;
 		newShip.isShielded = isShielded;
@@ -173,6 +174,7 @@ public class Ship extends AbstractActionableObject {
 		newShip.killsInflicted = killsInflicted;
 		newShip.killsReceived = killsReceived;
 		newShip.damageInflicted = damageInflicted;
+		newShip.damageReceived = damageReceived;
 		newShip.carryingFlag = carryingFlag;
 		newShip.numFlags = numFlags;
 		newShip.isShielded = isShielded;


### PR DESCRIPTION
damageReceived was not being cloned in Ship's deepClone which prevented getDamageReceived() from returning correct values when used in onMovementStart()