### PR TITLE
Fixed issue where teams' MouseAdapters wouldn't be added to the GUI

### DIFF
--- a/src/spacesettlers/gui/SpaceSettlersGUI.java
+++ b/src/spacesettlers/gui/SpaceSettlersGUI.java
@@ -164,7 +164,7 @@ public class SpaceSettlersGUI {
 			}
 
 			MouseAdapter mouseListen = team.getMouseAdapter(clickTransform);
-			if (listener != null) {
+			if (mouseListen != null) {
 				mainComponent.addMouseListener(mouseListen);
 				//mainComponent.addMouseMotionListener(mouseListen);
 			}


### PR DESCRIPTION
The MouseAdapter from each team was only being added if the team also provided a KeyAdapter.