### PR TITLE
Gaming update

### DIFF
--- a/config/heuristicCooperative/SpaceSettlersConfig.xml
+++ b/config/heuristicCooperative/SpaceSettlersConfig.xml
@@ -71,7 +71,7 @@
 		<probabilityMineable>0.5</probabilityMineable>
 
 		<!-- The probability that a newly spawned asteroid will be gameable -->
-		<probabilityGameable>0.0</probabilityGameable>
+		<probabilityGameable>0.5</probabilityGameable>
 		
 		<!-- The number of asteroids when the game starts -->
 		<numberInitialAsteroids>40</numberInitialAsteroids>

--- a/src/spacesettlers/clients/AggressiveFlagCollectorTeamClient.java
+++ b/src/spacesettlers/clients/AggressiveFlagCollectorTeamClient.java
@@ -663,7 +663,7 @@ public class AggressiveFlagCollectorTeamClient extends TeamClient {
 	}
 
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/spacesettlers/clients/AggressiveHeuristicAsteroidCollectorSingletonTeamClient.java
+++ b/src/spacesettlers/clients/AggressiveHeuristicAsteroidCollectorSingletonTeamClient.java
@@ -443,7 +443,7 @@ public class AggressiveHeuristicAsteroidCollectorSingletonTeamClient extends Tea
 	}
 
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/spacesettlers/clients/AggressiveHeuristicAsteroidCollectorTeamClient.java
+++ b/src/spacesettlers/clients/AggressiveHeuristicAsteroidCollectorTeamClient.java
@@ -513,7 +513,7 @@ public class AggressiveHeuristicAsteroidCollectorTeamClient extends TeamClient {
 	}
 
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/spacesettlers/clients/AggressiveHeuristicGameAsteroidCollectorTeamClient.java
+++ b/src/spacesettlers/clients/AggressiveHeuristicGameAsteroidCollectorTeamClient.java
@@ -553,11 +553,11 @@ public class AggressiveHeuristicGameAsteroidCollectorTeamClient extends TeamClie
 	 * 
 	 */
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
-		HeuristicTicTacToe3DGameAgent agent = new HeuristicTicTacToe3DGameAgent(AbstractGame.player1);
+		HeuristicTicTacToe3DGameAgent agent = new HeuristicTicTacToe3DGameAgent();
 		
-		HashMap<UUID, AbstractGameAgent> actions = new HashMap<UUID, AbstractGameAgent>();
+		HashMap<UUID, AbstractGameAgent<?,?>> actions = new HashMap<>();
 
 		// loop through each ship
 		for (AbstractObject actionable :  actionableObjects) {

--- a/src/spacesettlers/clients/BeaconCollectorTeamClient.java
+++ b/src/spacesettlers/clients/BeaconCollectorTeamClient.java
@@ -163,7 +163,7 @@ public class BeaconCollectorTeamClient extends TeamClient {
 	}
 
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/spacesettlers/clients/CoreCollectorTeamClient.java
+++ b/src/spacesettlers/clients/CoreCollectorTeamClient.java
@@ -200,7 +200,7 @@ public class CoreCollectorTeamClient extends TeamClient {
 	}
 	
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/spacesettlers/clients/DoNothingTeamClient.java
+++ b/src/spacesettlers/clients/DoNothingTeamClient.java
@@ -77,7 +77,7 @@ public class DoNothingTeamClient extends TeamClient {
 	}
 
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/spacesettlers/clients/HumanTeamClient.java
+++ b/src/spacesettlers/clients/HumanTeamClient.java
@@ -291,7 +291,7 @@ public class HumanTeamClient extends TeamClient {
 	}
 	
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/spacesettlers/clients/InfiniteLoopTeamClient.java
+++ b/src/spacesettlers/clients/InfiniteLoopTeamClient.java
@@ -81,7 +81,7 @@ public class InfiniteLoopTeamClient extends TeamClient {
 	}
 
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/spacesettlers/clients/PacifistFlagCollectorTeamClient.java
+++ b/src/spacesettlers/clients/PacifistFlagCollectorTeamClient.java
@@ -537,7 +537,7 @@ public class PacifistFlagCollectorTeamClient extends TeamClient {
 	}
 
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/spacesettlers/clients/PacifistHeuristicAsteroidCollectorTeamClient.java
+++ b/src/spacesettlers/clients/PacifistHeuristicAsteroidCollectorTeamClient.java
@@ -374,7 +374,7 @@ public class PacifistHeuristicAsteroidCollectorTeamClient extends TeamClient {
 	}
 
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/spacesettlers/clients/PacifistHeuristicGameAsteroidCollectorTeamClient.java
+++ b/src/spacesettlers/clients/PacifistHeuristicGameAsteroidCollectorTeamClient.java
@@ -401,11 +401,10 @@ public class PacifistHeuristicGameAsteroidCollectorTeamClient extends TeamClient
 	 * 
 	 */
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
-		HeuristicTicTacToe3DGameAgent agent = new HeuristicTicTacToe3DGameAgent(AbstractGame.player1);
-		
-		HashMap<UUID, AbstractGameAgent> actions = new HashMap<UUID, AbstractGameAgent>();
+		HashMap<UUID, AbstractGameAgent<?,?>> actions = new HashMap<>();
+		HeuristicTicTacToe3DGameAgent agent = new HeuristicTicTacToe3DGameAgent();
 
 		// loop through each ship
 		for (AbstractObject actionable :  actionableObjects) {

--- a/src/spacesettlers/clients/RandomTeamClient.java
+++ b/src/spacesettlers/clients/RandomTeamClient.java
@@ -141,7 +141,7 @@ public class RandomTeamClient extends TeamClient {
 	}
 
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/spacesettlers/clients/Team.java
+++ b/src/spacesettlers/clients/Team.java
@@ -685,8 +685,8 @@ public class Team {
 	 * @param space
 	 * @return
 	 */
-	public Map<UUID, AbstractGameAgent> getTeamSearches(Toroidal2DPhysics space) {
-        Map<UUID, AbstractGameAgent> searches = new HashMap<UUID,AbstractGameAgent>();
+	public Map<UUID, AbstractGameAgent<?,?>> getTeamSearches(Toroidal2DPhysics space) {
+        Map<UUID, AbstractGameAgent<?,?>> searches = new HashMap<UUID,AbstractGameAgent<?,?>>();
 
 		final Toroidal2DPhysics clonedSpace = space.deepClone();
 		final Set<AbstractActionableObject> clonedActionableObjects = getTeamActionableObjectsClone(space);
@@ -699,9 +699,9 @@ public class Team {
 		}
 
 		//System.out.println("exec " + executor.isTerminated());
-        Future<Map<UUID,AbstractGameAgent>> future = executor.submit(
-        		new Callable<Map<UUID,AbstractGameAgent>>(){
-        			public Map<UUID,AbstractGameAgent> call() throws Exception {
+        Future<Map<UUID,AbstractGameAgent<?,?>>> future = executor.submit(
+        		new Callable<Map<UUID,AbstractGameAgent<?,?>>>(){
+        			public Map<UUID,AbstractGameAgent<?,?>> call() throws Exception {
         				return teamClient.getGameSearch(clonedSpace, clonedActionableObjects);
         			}
         		});
@@ -714,20 +714,20 @@ public class Team {
             //was terminated
         	//return empty map, don't buy anything
         	System.out.println(getTeamName() + " timed out in getTeamPowerups");
-        	searches = new HashMap<UUID,AbstractGameAgent>();
+        	searches = new HashMap<UUID,AbstractGameAgent<?,?>>();
         } catch (InterruptedException e) {
         	//we were interrupted (should not happen but lets be good programmers) 
         	//return empty map, don't buy anything
-        	searches = new HashMap<UUID,AbstractGameAgent>();
+        	searches = new HashMap<UUID,AbstractGameAgent<?,?>>();
 			e.printStackTrace();
 		} catch (ExecutionException e) {
 			//the executor threw and exception (should not happen but lets be good programmers) 
         	//return empty map, don't buy anything
-			searches = new HashMap<UUID,AbstractGameAgent>();
+			searches = new HashMap<UUID,AbstractGameAgent<?,?>>();
 			e.printStackTrace();
 		} catch (Exception e) {
 			System.err.println("Error in agent.  Printing stack trace");
-        	searches = new HashMap<UUID,AbstractGameAgent>();
+        	searches = new HashMap<UUID,AbstractGameAgent<?,?>>();
 			e.printStackTrace();
 		}
 

--- a/src/spacesettlers/clients/TeamClient.java
+++ b/src/spacesettlers/clients/TeamClient.java
@@ -155,7 +155,7 @@ abstract public class TeamClient {
 	 * @param actionableObjects the shipsfor this team
 	 * @return
 	 */
-	abstract public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space, 
+	abstract public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space, 
 			Set<AbstractActionableObject> actionableObjects);
 
 	

--- a/src/spacesettlers/clients/examples/ExampleGAClient.java
+++ b/src/spacesettlers/clients/examples/ExampleGAClient.java
@@ -180,7 +180,7 @@ public class ExampleGAClient extends TeamClient {
 	}
 	
 	@Override
-	public Map<UUID, AbstractGameAgent> getGameSearch(Toroidal2DPhysics space,
+	public Map<UUID, AbstractGameAgent<?,?>> getGameSearch(Toroidal2DPhysics space,
 			Set<AbstractActionableObject> actionableObjects) {
 		// TODO Auto-generated method stub
 		return null;

--- a/src/spacesettlers/game/AbstractGame.java
+++ b/src/spacesettlers/game/AbstractGame.java
@@ -6,11 +6,9 @@ package spacesettlers.game;
  * @author amy
  *
  */
-public abstract class AbstractGame {
-	 public static int player1 = 1;
-	 public static int player2 = 2;
-	 
-	 int heuristicPlayer;
+public abstract class AbstractGame<T extends AbstractGameBoard, U extends AbstractGameAgent<T, ? extends AbstractGameAction>> {
+	 public static int PLAYER1_ID = 1;
+	 public static int PLAYER2_ID = 2;
 	
 	/** 
 	 * Is the game over?
@@ -26,9 +24,9 @@ public abstract class AbstractGame {
 	public abstract boolean getTurn();
 	
 	/**
-	 * Play the action for the current player
+	 * Play the action for the player.
 	 */
-	public abstract void playAction(AbstractGameAction action);
+	public abstract void playCurrentTurn();
 	
 	/**
 	 * Return the winning player (remember players are true and false)
@@ -41,14 +39,6 @@ public abstract class AbstractGame {
 	 * Get the game board
 	 * @return
 	 */
-	public abstract AbstractGameBoard getBoard();
-
-	/**
-	 * Return the heuristic player (set inside the actual game initialization)
-	 * @return
-	 */
-	public int getHeuristicPlayer() {
-		return heuristicPlayer;
-	}
+	public abstract T getBoard();
 	
 }

--- a/src/spacesettlers/game/AbstractGameAgent.java
+++ b/src/spacesettlers/game/AbstractGameAgent.java
@@ -5,18 +5,18 @@ package spacesettlers.game;
  * @author amy
  *
  */
-public abstract class AbstractGameAgent {
+public abstract class AbstractGameAgent<T extends AbstractGameBoard, U extends AbstractGameAction> {
 	int player;
 
 	/**
 	 * All game agents must be able to return a next move
-	 * @param game
+	 * @param board
 	 * @return
 	 */
-	public abstract AbstractGameAction getNextMove(AbstractGame game);
+	public abstract U getNextMove(T board);
 
 	
-	public int getPlayer() {
+	public int getPlayerID() {
 		return player;
 	}
 

--- a/src/spacesettlers/game/GameFactory.java
+++ b/src/spacesettlers/game/GameFactory.java
@@ -9,7 +9,7 @@ package spacesettlers.game;
  */
 
 public class GameFactory {
-	public static AbstractGame generateNewGame() {
-		return new TicTacToe3D();
+	public static TicTacToe3D generateNewGame(final TicTacToe3DGameAgent player_lhs, final TicTacToe3DGameAgent player_rhs) {
+		return new TicTacToe3D(player_lhs, player_rhs);
 	}
 }

--- a/src/spacesettlers/game/HeuristicTicTacToe3DGameAgent.java
+++ b/src/spacesettlers/game/HeuristicTicTacToe3DGameAgent.java
@@ -6,11 +6,7 @@ package spacesettlers.game;
  * @author amy
  *
  */
-public class HeuristicTicTacToe3DGameAgent extends AbstractGameAgent {
-	public HeuristicTicTacToe3DGameAgent(int player) {
-		this.player = player;
-	}
-
+public class HeuristicTicTacToe3DGameAgent extends TicTacToe3DGameAgent {
 	/**
 	 * First see if we can win in one and then otherwise take the first available 
 	 * (this will be improved over time)
@@ -18,20 +14,19 @@ public class HeuristicTicTacToe3DGameAgent extends AbstractGameAgent {
 	 * @param game
 	 * @return
 	 */
-	public AbstractGameAction getNextMove(AbstractGame game) {
-		TicTacToe3DBoard board = (TicTacToe3DBoard) game.getBoard();
-		
+	@Override
+	public TicTacToe3DAction getNextMove(final TicTacToe3DBoard board) {	
 		// check to see if the center is free
-		if (board.board[1][1][1] == board.empty) {
+		if (board.board[1][1][1] == TicTacToe3DBoard.EMPTY) {
 			return new TicTacToe3DAction(1, 1, 1);
 		}
 		
 		// check to see if the other two centers are free
-		if (board.board[1][1][0] == board.empty) {
+		if (board.board[1][1][0] == TicTacToe3DBoard.EMPTY) {
 			return new TicTacToe3DAction(1, 1, 0);
 		}
 
-		if (board.board[1][1][2] == board.empty) {
+		if (board.board[1][1][2] == TicTacToe3DBoard.EMPTY) {
 			return new TicTacToe3DAction(1, 1, 2);
 		}
 
@@ -39,14 +34,14 @@ public class HeuristicTicTacToe3DGameAgent extends AbstractGameAgent {
 		for (int i = 0; i < 3; i++) {
 			for (int j = 0; j < 3; j++) {
 				for (int k = 0; k < 3; k++) {
-					if (board.board[i][j][k] == board.empty) {
+					if (board.board[i][j][k] == TicTacToe3DBoard.EMPTY) {
 						TicTacToe3DAction action = new TicTacToe3DAction(i, j, k);
 						board.makeMove(action, this.player);
 						if (board.getWinningPlayer() == this.player) {
 							return action;
 						}
 						// unmake the move
-						board.board[i][j][k] = board.empty;
+						board.board[i][j][k] = TicTacToe3DBoard.EMPTY;
 					}
 				}
 			}
@@ -57,7 +52,7 @@ public class HeuristicTicTacToe3DGameAgent extends AbstractGameAgent {
 		for (int i = 0; i < 3; i++) {
 			for (int j = 0; j < 3; j++) {
 				for (int k = 0; k < 3; k++) {
-					if (board.board[i][j][k] == board.empty) {
+					if (board.board[i][j][k] == TicTacToe3DBoard.EMPTY) {
 						return new TicTacToe3DAction(i, j, k);
 					}
 				}

--- a/src/spacesettlers/game/TicTacToe3D.java
+++ b/src/spacesettlers/game/TicTacToe3D.java
@@ -8,31 +8,42 @@ import java.util.Random;
  * @author amy
  *
  */
-public class TicTacToe3D extends AbstractGame {
+public class TicTacToe3D extends AbstractGame<TicTacToe3DBoard, TicTacToe3DGameAgent> implements Runnable {
 	TicTacToe3DBoard myBoard;
-	private boolean currentPlayer;
-	private Random random;
+	private boolean isPlayer1Turn;
+	
+	final TicTacToe3DGameAgent player1, player2;
 
 	/**
-	 * Initialize an empty board and choose a random first player
+	 * Initialize an empty board and randomly assign selected players as player1 and player2.
+	 * @param player_lhs 
+	 * @param player_rhs
 	 */
-	public TicTacToe3D() {
+	public TicTacToe3D(final TicTacToe3DGameAgent player_lhs, final TicTacToe3DGameAgent player_rhs) {
 		myBoard = new TicTacToe3DBoard();
-		random = new Random();
-		currentPlayer = random.nextBoolean();
-		super.heuristicPlayer = player1;
+		
+		final Random random = new Random();
+		isPlayer1Turn = new Random().nextBoolean();
+		
+		if (random.nextBoolean()) {
+			(player1 = player_lhs).setPlayer(AbstractGame.PLAYER1_ID);
+			(player2 = player_rhs).setPlayer(AbstractGame.PLAYER2_ID);
+		} else {
+			(player1 = player_rhs).setPlayer(AbstractGame.PLAYER1_ID);
+			(player2 = player_lhs).setPlayer(AbstractGame.PLAYER2_ID);
+		}
 	}
 
 	/**
 	 * Used only for unit tests so the board is set to something specific
 	 * @param board
 	 */
-	public TicTacToe3D(int [][][]board, boolean player) {
+	public TicTacToe3D(int [][][]board, boolean isPlayer1Turn, TicTacToe3DGameAgent player1, TicTacToe3DGameAgent player2) {
 		this.myBoard = new TicTacToe3DBoard();
 		this.myBoard.setBoard(board);
-		currentPlayer = player;
-		random = new Random();
-		super.heuristicPlayer = player1;
+		this.isPlayer1Turn = isPlayer1Turn;
+		(this.player1 = player1).setPlayer(1);
+		(this.player2 = player2).setPlayer(2);
 	}
 
 
@@ -42,11 +53,7 @@ public class TicTacToe3D extends AbstractGame {
 	 * @return true if the game is over and false otherwise
 	 */
 	public boolean isGameOver() {
-		if (myBoard.getWinningPlayer() != myBoard.empty) {
-			return true;
-		} else {
-			return false;
-		}
+		return myBoard.getWinningPlayer() != TicTacToe3DBoard.EMPTY;
 		
 	}
 
@@ -54,33 +61,40 @@ public class TicTacToe3D extends AbstractGame {
 	 * Return true if is player 1's turn
 	 */
 	public boolean getTurn() {
-		return currentPlayer;
+		return isPlayer1Turn;
 	}
 
 	@Override
-	public void playAction(AbstractGameAction action) {
-		TicTacToe3DAction TTTAction = (TicTacToe3DAction) action;
-		int player = player1;
-		
-		if (!currentPlayer) {
-			player = player2;
-		}
-		currentPlayer = !currentPlayer;
-		
-		this.myBoard.makeMove(TTTAction, player);
+	public void playCurrentTurn() {
+		final TicTacToe3DGameAgent player = getCurrentPlayer();
+		myBoard.makeMove(player.getNextMove(myBoard), player.getPlayerID());
+		isPlayer1Turn = !isPlayer1Turn;
 	}
 
 	/**
-	 * Returns true if player 1 is the winner.  
+	 * Returns the winning player id if any. Else, the empty value (0).
 	 */
 	public int getWinner() {
 		return myBoard.getWinningPlayer();
 	}
 
 	@Override
-	public AbstractGameBoard getBoard() {
+	public TicTacToe3DBoard getBoard() {
 		return myBoard.deepClone();
 	}
 
+	/**
+	 * @return The player whose turn it is currently.
+	 */
+	public TicTacToe3DGameAgent getCurrentPlayer() {
+		return isPlayer1Turn ? player1 : player2;
+	}
+
+	@Override
+	public void run() {
+		while (!isGameOver()) {
+			playCurrentTurn();
+		}
+	}
 
 }

--- a/src/spacesettlers/game/TicTacToe3DBoard.java
+++ b/src/spacesettlers/game/TicTacToe3DBoard.java
@@ -2,7 +2,7 @@ package spacesettlers.game;
 
 public class TicTacToe3DBoard extends AbstractGameBoard {
 	int[][][] board;
-	static int empty = 0;
+	static int EMPTY = 0;
 	static int board_size = 3;
 
 	public TicTacToe3DBoard() {
@@ -14,7 +14,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 	 * @return
 	 */
 	public static int getEmpty() {
-		return empty;
+		return EMPTY;
 	}
 
 
@@ -43,7 +43,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 			for (int row = 0; row < board_size; row++) {
 				int num_in_row = 1;
 				int player = board[row][0][dep]; 
-				if (player != empty) {
+				if (player != EMPTY) {
 					for (int col = 1; col < board_size; col++) {
 						if (board[row][col][dep] == player) {
 							num_in_row++;
@@ -62,7 +62,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 				int num_in_row = 1;
 				int player = board[0][col][dep];  
 
-				if (player != empty) {
+				if (player != EMPTY) {
 					for (int row = 1; row < board_size; row++) {
 						if (board[row][col][dep] == player) {
 							num_in_row++;
@@ -79,7 +79,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 			// check the diagonals
 			int player = board[0][0][dep];
 			int num_in_row = 1;
-			if (player != empty) {
+			if (player != EMPTY) {
 				for (int row = 1; row < board_size; row++) {
 					if (board[row][row][dep] == player) {
 						num_in_row++;
@@ -94,7 +94,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 
 			player = board[0][board_size-1][dep];  
 			num_in_row = 1;
-			if (player != empty) {
+			if (player != EMPTY) {
 				for (int row = 1; row < board_size; row++) {
 					if (board[row][board_size-row-1][dep] == player) {
 						num_in_row++;
@@ -114,7 +114,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 		
 		//Cross diagonals (4)
 		centerPoint = board [1][1][1];
-		if (centerPoint != empty) {
+		if (centerPoint != EMPTY) {
 			
 			/*
 					x-- --- ---
@@ -165,7 +165,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 					x-- --- ---
 		*/
 		centerPoint = board[1][0][1];
-		if (centerPoint != empty) {
+		if (centerPoint != EMPTY) {
 			if ((board[0][0][0] == centerPoint)  && (board[2][0][2] == centerPoint)) {
 				return centerPoint;
 			}
@@ -186,7 +186,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 					-x- --- ---
 		*/
 		centerPoint = board[1][1][1];
-		if (centerPoint != empty) {
+		if (centerPoint != EMPTY) {
 			if ((board[0][1][0] == centerPoint)  && (board[2][1][2] == centerPoint)) {
 				return centerPoint;
 			}
@@ -207,7 +207,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 					--- --- --x
 		*/
 		centerPoint = board[1][2][1];
-		if (centerPoint != empty) {
+		if (centerPoint != EMPTY) {
 			if ((board[2][2][0] == centerPoint)  && (board[0][2][2] == centerPoint)) {
 				return centerPoint;
 			}
@@ -229,7 +229,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 					--- --- ---
 		*/
 		centerPoint = board[0][1][1];
-		if (centerPoint != empty) {
+		if (centerPoint != EMPTY) {
 			if ((board[0][0][0] == centerPoint)  && (board[0][2][2] == centerPoint)) {
 				return centerPoint;
 			}
@@ -250,7 +250,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 					--- --- ---
 		*/
 		centerPoint = board[1][1][1];
-		if (centerPoint != empty) {
+		if (centerPoint != EMPTY) {
 			if ((board[1][0][0] == centerPoint)  && (board[1][2][2] == centerPoint)) {
 				return centerPoint;
 			}
@@ -271,7 +271,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 					--x -x- x--
 		*/
 		centerPoint = board[2][1][1];
-		if (centerPoint != empty) {
+		if (centerPoint != EMPTY) {
 			if ((board[2][0][0] == centerPoint)  && (board[2][2][2] == centerPoint)) {
 				return centerPoint;
 			}
@@ -291,7 +291,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 			for (int col = 0; col < board_size; col++) {
 				int num_in_pillar = 1;
 				int player = board[row][col][0];
-				if (player != empty) {
+				if (player != EMPTY) {
 					for (int dep = 1; dep < board_size; dep++) {
 						if (board[row][col][dep] == player) {
 							num_in_pillar++;
@@ -307,7 +307,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 		}
 
 
-		return empty;
+		return EMPTY;
 	}
 	
 	
@@ -336,7 +336,7 @@ public class TicTacToe3DBoard extends AbstractGameBoard {
 	 * @param player
 	 */
 	public void makeMove(TicTacToe3DAction TTTAction, int player) {
-		if (board[TTTAction.row][TTTAction.col][TTTAction.depth] == empty) {
+		if (board[TTTAction.row][TTTAction.col][TTTAction.depth] == EMPTY) {
 			board[TTTAction.row][TTTAction.col][TTTAction.depth] = player;
 		}
 	}

--- a/src/spacesettlers/game/TicTacToe3DGameAgent.java
+++ b/src/spacesettlers/game/TicTacToe3DGameAgent.java
@@ -1,0 +1,5 @@
+package spacesettlers.game;
+
+public abstract class TicTacToe3DGameAgent extends AbstractGameAgent<TicTacToe3DBoard, TicTacToe3DAction> {
+
+}

--- a/src/spacesettlers/simulator/CollisionHandler.java
+++ b/src/spacesettlers/simulator/CollisionHandler.java
@@ -1,21 +1,20 @@
 package spacesettlers.simulator;
 
+import java.util.concurrent.ThreadLocalRandom;
+
+import spacesettlers.game.AbstractGameAgent;
+import spacesettlers.game.GameFactory;
+import spacesettlers.game.HeuristicTicTacToe3DGameAgent;
+import spacesettlers.game.TicTacToe3D;
+import spacesettlers.game.TicTacToe3DGameAgent;
+import spacesettlers.objects.AbstractObject;
+import spacesettlers.objects.AiCore;
 import spacesettlers.objects.Asteroid;
 import spacesettlers.objects.Base;
 import spacesettlers.objects.Beacon;
 import spacesettlers.objects.Drone;
 import spacesettlers.objects.Flag;
 import spacesettlers.objects.Ship;
-
-import java.util.concurrent.ThreadLocalRandom;
-
-import spacesettlers.game.AbstractGame;
-import spacesettlers.game.AbstractGameAction;
-import spacesettlers.game.AbstractGameAgent;
-import spacesettlers.game.GameFactory;
-import spacesettlers.game.HeuristicTicTacToe3DGameAgent;
-import spacesettlers.objects.AbstractObject;
-import spacesettlers.objects.AiCore;
 import spacesettlers.objects.weapons.EMP;
 import spacesettlers.objects.weapons.Missile;
 import spacesettlers.utilities.Position;
@@ -494,31 +493,21 @@ public class CollisionHandler {
 	 * 
 	 * @return
 	 */
-	public boolean playGame(AbstractGameAgent opponent) {
-		AbstractGame game = GameFactory.generateNewGame();
-		int asteroidPlayer = game.getHeuristicPlayer();
-		
-		HeuristicTicTacToe3DGameAgent myPlayer = new HeuristicTicTacToe3DGameAgent(asteroidPlayer);
-		AbstractGameAction action;
-		
-		if (opponent == null) {
+	public boolean playGame(AbstractGameAgent<?,?> opponent) {		
+		if (!TicTacToe3DGameAgent.class.isInstance(opponent)) {
 			System.out.println("Gaming asteroid reached and no player specified by opponent: Winner is asteroid.");
 			return false;
 		} else {
 			System.out.println("Gaming asteroid reached and proceeding with game");
 		}
+
+		HeuristicTicTacToe3DGameAgent asteroidPlayer = new HeuristicTicTacToe3DGameAgent();
 		
-		while (!game.isGameOver()) {
-			if (game.getTurn()) {
-				action = myPlayer.getNextMove(game);
-			} else {
-				action = opponent.getNextMove(game);
-			}
-			game.playAction(action);
-		}
+		final TicTacToe3D game = GameFactory.generateNewGame(asteroidPlayer, TicTacToe3DGameAgent.class.cast(opponent));
+		game.run();
 
 		// returns true if the winner was the ship agent
-		if (game.getWinner() == asteroidPlayer) {
+		if (game.getWinner() == asteroidPlayer.getPlayerID()) {
 			System.out.println("Gaming asteroid reached: Winner is asteroid.");
 			return false;
 		} else {

--- a/src/spacesettlers/simulator/SpaceSettlersSimulator.java
+++ b/src/spacesettlers/simulator/SpaceSettlersSimulator.java
@@ -708,9 +708,9 @@ public final class SpaceSettlersSimulator {
 		}
 
 		// get the game searches being used on this turn
-		Map<UUID, AbstractGameAgent> allSearches = new HashMap<UUID, AbstractGameAgent>();
+		Map<UUID, AbstractGameAgent<?,?>> allSearches = new HashMap<>();
 		for (Team team : teams) {
-			Map<UUID, AbstractGameAgent> searches = team.getTeamSearches(simulatedSpace);
+			Map<UUID, AbstractGameAgent<?,?>> searches = team.getTeamSearches(simulatedSpace);
 			if (searches != null) {
 				for (UUID key : searches.keySet()) {
 					// verify searches belong to this team

--- a/test/spacesettlers/game/TestTicTacToe3D.java
+++ b/test/spacesettlers/game/TestTicTacToe3D.java
@@ -1,17 +1,13 @@
 package spacesettlers.game;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import spacesettlers.actions.MoveAction;
 import spacesettlers.actions.SpaceSettlersActionException;
-import spacesettlers.simulator.Toroidal2DPhysics;
-import spacesettlers.utilities.Movement;
-import spacesettlers.utilities.Position;
-import spacesettlers.utilities.Vector2D;
 
 /**
  * Ensure the Tic Tac Toe game mechanics work
@@ -23,7 +19,7 @@ public class TestTicTacToe3D {
 	
 	@Before
 	public void setUp() throws Exception {
-		game = new TicTacToe3D();
+		game = new TicTacToe3D(null, null);
 	}
 
 	@After
@@ -38,7 +34,7 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverEmptyBoard() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true);
+		game = new TicTacToe3D(board, true, null, null);
 		
 		// an empty board should not be over
 		assertFalse(game.isGameOver());
@@ -52,13 +48,13 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverScatteredBoard() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true);
+		game = new TicTacToe3D(board, true, null, null);
 		
 		// a board with a few scattered moves should not be over
 		board[0][0][0] = 1;
 		board[0][1][0] = 2;
 		board[1][0][2] = 1;
-		game = new TicTacToe3D(board, true);
+		game = new TicTacToe3D(board, true, null, null);
 		// an empty board should not be over
 		assertFalse(game.isGameOver());
 	}
@@ -71,14 +67,14 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverWinnerRow2D() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true);
+		game = new TicTacToe3D(board, true, null, null);
 
 		for (int dep = 0; dep < 3; dep++) {
 			board = new int[3][3][3];
 			board[0][0][dep] = 1;
 			board[0][1][dep] = 1;
 			board[0][2][dep] = 1;
-			game = new TicTacToe3D(board, true);
+			game = new TicTacToe3D(board, true, null, null);
 			assertTrue(game.isGameOver());
 		}
 	}
@@ -91,14 +87,14 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverWinnerCol2D() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true);
+		game = new TicTacToe3D(board, true, null, null);
 
 		for (int dep = 0; dep < 3; dep++) {
 			board = new int[3][3][3];
 			board[0][0][dep] = 1;
 			board[1][0][dep] = 1;
 			board[2][0][dep] = 1;
-			game = new TicTacToe3D(board, true);
+			game = new TicTacToe3D(board, true, null, null);
 			assertTrue(game.isGameOver());
 		}
 	}
@@ -111,14 +107,14 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverWinnerDiagonal2D() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true);
+		game = new TicTacToe3D(board, true, null, null);
 
 		for (int dep = 0; dep < 3; dep++) {
 			board = new int[3][3][3];
 			board[0][0][dep] = 1;
 			board[1][1][dep] = 1;
 			board[2][2][dep] = 1;
-			game = new TicTacToe3D(board, true);
+			game = new TicTacToe3D(board, true, null, null);
 			assertTrue(game.isGameOver());
 		}
 
@@ -127,7 +123,7 @@ public class TestTicTacToe3D {
 			board[0][2][dep] = 1;
 			board[1][1][dep] = 1;
 			board[2][0][dep] = 1;
-			game = new TicTacToe3D(board, true);
+			game = new TicTacToe3D(board, true, null, null);
 			assertTrue(game.isGameOver());
 		}
 
@@ -141,14 +137,14 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverWinnerRow3D() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true);
+		game = new TicTacToe3D(board, true, null, null);
 
 		for (int dep = 0; dep < 3; dep++) {
 			board = new int[3][3][3];
 			board[0][0][dep] = 1;
 			board[1][0][dep] = 1;
 			board[2][0][dep] = 1;
-			game = new TicTacToe3D(board, true);
+			game = new TicTacToe3D(board, true, null, null);
 			assertTrue(game.isGameOver());
 		}
 	}
@@ -161,14 +157,14 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverWinnerCol3D() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true);
+		game = new TicTacToe3D(board, true, null, null);
 
 		for (int dep = 0; dep < 3; dep++) {
 			board = new int[3][3][3];
 			board[0][0][dep] = 1;
 			board[0][1][dep] = 1;
 			board[0][2][dep] = 1;
-			game = new TicTacToe3D(board, true);
+			game = new TicTacToe3D(board, true, null, null);
 			assertTrue(game.isGameOver());
 		}
 	}
@@ -181,33 +177,33 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverWinnerDiagonal3D() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true);
+		game = new TicTacToe3D(board, true, null, null);
 
 		board[0][0][0] = 1;
 		board[1][1][1] = 1;
 		board[2][2][2] = 1;
-		game = new TicTacToe3D(board, true);
+		game = new TicTacToe3D(board, true, null, null);
 		assertTrue(game.isGameOver());
 
 		board = new int[3][3][3];
 		board[2][0][0] = 1;
 		board[1][1][1] = 1;
 		board[0][2][2] = 1;
-		game = new TicTacToe3D(board, true);
+		game = new TicTacToe3D(board, true, null, null);
 		assertTrue(game.isGameOver());
 
 		board = new int[3][3][3];
 		board[0][0][2] = 1;
 		board[1][1][1] = 1;
 		board[2][2][0] = 1;
-		game = new TicTacToe3D(board, true);
+		game = new TicTacToe3D(board, true, null, null);
 		assertTrue(game.isGameOver());
 
 		board = new int[3][3][3];
 		board[0][2][0] = 1;
 		board[1][1][1] = 1;
 		board[2][0][2] = 1;
-		game = new TicTacToe3D(board, true);
+		game = new TicTacToe3D(board, true, null, null);
 		assertTrue(game.isGameOver());
 
 		

--- a/test/spacesettlers/game/TestTicTacToe3D.java
+++ b/test/spacesettlers/game/TestTicTacToe3D.java
@@ -17,9 +17,19 @@ import spacesettlers.actions.SpaceSettlersActionException;
 public class TestTicTacToe3D {
 	TicTacToe3D game;
 	
+	private static final class MockTicTacToe3DGameAgent extends TicTacToe3DGameAgent {
+		@Override
+		public TicTacToe3DAction getNextMove(TicTacToe3DBoard board) {
+			return null;
+		}
+		
+	}
+	
+	private static final MockTicTacToe3DGameAgent mockAgent = new MockTicTacToe3DGameAgent();
+	
 	@Before
 	public void setUp() throws Exception {
-		game = new TicTacToe3D(null, null);
+		game = new TicTacToe3D(mockAgent, mockAgent);
 	}
 
 	@After
@@ -34,7 +44,7 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverEmptyBoard() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true, null, null);
+		game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 		
 		// an empty board should not be over
 		assertFalse(game.isGameOver());
@@ -48,13 +58,13 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverScatteredBoard() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true, null, null);
+		game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 		
 		// a board with a few scattered moves should not be over
 		board[0][0][0] = 1;
 		board[0][1][0] = 2;
 		board[1][0][2] = 1;
-		game = new TicTacToe3D(board, true, null, null);
+		game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 		// an empty board should not be over
 		assertFalse(game.isGameOver());
 	}
@@ -67,14 +77,14 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverWinnerRow2D() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true, null, null);
+		game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 
 		for (int dep = 0; dep < 3; dep++) {
 			board = new int[3][3][3];
 			board[0][0][dep] = 1;
 			board[0][1][dep] = 1;
 			board[0][2][dep] = 1;
-			game = new TicTacToe3D(board, true, null, null);
+			game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 			assertTrue(game.isGameOver());
 		}
 	}
@@ -87,14 +97,14 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverWinnerCol2D() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true, null, null);
+		game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 
 		for (int dep = 0; dep < 3; dep++) {
 			board = new int[3][3][3];
 			board[0][0][dep] = 1;
 			board[1][0][dep] = 1;
 			board[2][0][dep] = 1;
-			game = new TicTacToe3D(board, true, null, null);
+			game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 			assertTrue(game.isGameOver());
 		}
 	}
@@ -107,14 +117,14 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverWinnerDiagonal2D() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true, null, null);
+		game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 
 		for (int dep = 0; dep < 3; dep++) {
 			board = new int[3][3][3];
 			board[0][0][dep] = 1;
 			board[1][1][dep] = 1;
 			board[2][2][dep] = 1;
-			game = new TicTacToe3D(board, true, null, null);
+			game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 			assertTrue(game.isGameOver());
 		}
 
@@ -123,7 +133,7 @@ public class TestTicTacToe3D {
 			board[0][2][dep] = 1;
 			board[1][1][dep] = 1;
 			board[2][0][dep] = 1;
-			game = new TicTacToe3D(board, true, null, null);
+			game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 			assertTrue(game.isGameOver());
 		}
 
@@ -137,14 +147,14 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverWinnerRow3D() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true, null, null);
+		game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 
 		for (int dep = 0; dep < 3; dep++) {
 			board = new int[3][3][3];
 			board[0][0][dep] = 1;
 			board[1][0][dep] = 1;
 			board[2][0][dep] = 1;
-			game = new TicTacToe3D(board, true, null, null);
+			game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 			assertTrue(game.isGameOver());
 		}
 	}
@@ -157,14 +167,14 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverWinnerCol3D() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true, null, null);
+		game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 
 		for (int dep = 0; dep < 3; dep++) {
 			board = new int[3][3][3];
 			board[0][0][dep] = 1;
 			board[0][1][dep] = 1;
 			board[0][2][dep] = 1;
-			game = new TicTacToe3D(board, true, null, null);
+			game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 			assertTrue(game.isGameOver());
 		}
 	}
@@ -177,33 +187,33 @@ public class TestTicTacToe3D {
 	@Test
 	public void testIsGameOverWinnerDiagonal3D() {
 		int [][][] board = new int[3][3][3];
-		game = new TicTacToe3D(board, true, null, null);
+		game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 
 		board[0][0][0] = 1;
 		board[1][1][1] = 1;
 		board[2][2][2] = 1;
-		game = new TicTacToe3D(board, true, null, null);
+		game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 		assertTrue(game.isGameOver());
 
 		board = new int[3][3][3];
 		board[2][0][0] = 1;
 		board[1][1][1] = 1;
 		board[0][2][2] = 1;
-		game = new TicTacToe3D(board, true, null, null);
+		game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 		assertTrue(game.isGameOver());
 
 		board = new int[3][3][3];
 		board[0][0][2] = 1;
 		board[1][1][1] = 1;
 		board[2][2][0] = 1;
-		game = new TicTacToe3D(board, true, null, null);
+		game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 		assertTrue(game.isGameOver());
 
 		board = new int[3][3][3];
 		board[0][2][0] = 1;
 		board[1][1][1] = 1;
 		board[2][0][2] = 1;
-		game = new TicTacToe3D(board, true, null, null);
+		game = new TicTacToe3D(board, true, mockAgent, mockAgent);
 		assertTrue(game.isGameOver());
 
 		


### PR DESCRIPTION
"Dynamically setting game agent player ids when the game is instantiated (independent of who goes first). Decoupled game agent and game bi-directional dependency. Added templating to reduce object type casting. Added TicTacToeGameAgent abstract class. Updated clients and junit tests with these changes."

The broader change in this update is templatizing the game object to expect a type of game action and game agent. This largely eliminates the need to constantly check object types. Future expansions to the gaming functionality can then have less hierarchical overlap. To this end, I had to decouple the strong dependencies between the game agent and the game, otherwise the templating would be a huge mess. If in the future it is important for players to know who went first, either appending that type of metainformation to the game board or creating a game metadata object would be the best practice to avoid that circular dependency issue.

One potential issue I realized during this is that game search agents are updated every game update cycle (at least as far as I can tell). The issue is that it would scale poorly with a lot of ships as either: 1) multiple new search agents are instantiated every frame, rather than being instantiated on-demand and 2) a single search agent reference is shared across multiple ships, which might behave abnormally if then multiple ships collide with a gaming asteroid on the same update frame (not very likely, but the probability scales as more ships/asteroids are in the environment).